### PR TITLE
- add the possibility to run the tool remotely through ssh

### DIFF
--- a/log/logger_client.py
+++ b/log/logger_client.py
@@ -8,10 +8,11 @@ from logging.handlers import RotatingFileHandler
 def set_logger():
     """Sets logger."""
     logs_dir = os.getenv("METRICS_LOGS_PATH")
+    logs_instance = os.getenv("METRICS_LOGS_INSTANCE", None)
     if logs_dir:
-        log_path = os.path.join(logs_dir, 'mq_client.log')
+        log_path = os.path.join(logs_dir, 'mq_client_{0}.log'.format(logs_instance if logs_instance is not None else ''))
     else:
-        log_path = os.path.join('log', 'mq_client.log')
+        log_path = os.path.join('log', 'mq_client_{0}.log'.format(logs_instance if logs_instance is not None else ''))
     # It means DEBUG level - https://docs.python.org/2.7/library/logging.html#levels
     log_level = 10
     logger = logging.getLogger("mq_client_logger")

--- a/modules/mq_api.py
+++ b/modules/mq_api.py
@@ -5,18 +5,34 @@ import subprocess
 
 def run_mq_command(**kwargs):
     """Calls predefined MQSC commands and returns their result."""
-    command_mapping = {
-        'get_channels': 'display channel (*)',
-        'get_chstatus': 'display chstatus({0}) BATCHES BUFSRCVD BUFSSENT BYTSRCVD BYTSSENT CHSTADA CHSTATI JOBNAME LSTMSGDA LSTMSGTI MSGS',
-        'get_channel': 'display channel({0})',
-        'get_listeners': 'display listener(*)',
-        'get_listener': 'display listener({0})',
-        'get_lsstatus': 'display lsstatus({0})',
-        'get_mq_manager_status': 'dspmq -m {0} -o all',
-        'get_mq_managers': 'dspmq',
-        'get_queues': 'display queue(*) TYPE(QLOCAL) CURDEPTH MAXDEPTH',
-        'get_queues_monitor': 'display qstatus(*) MONITOR'
-    }
+    ssh_connect_string = kwargs.get("ssh_connect_string", None)
+    if ssh_connect_string:
+        # escaped command for going through ssh
+        command_mapping = {
+            'get_channels': 'display channel \(\*\)',
+            'get_chstatus': 'display chstatus\({0}\) BATCHES BUFSRCVD BUFSSENT BYTSRCVD BYTSSENT CHSTADA CHSTATI JOBNAME LSTMSGDA LSTMSGTI MSGS',
+            'get_channel': 'display channel\({0}\)',
+            'get_listeners': 'display listener\(\*\)',
+            'get_listener': 'display listener\({0}\)',
+            'get_lsstatus': 'display lsstatus\({0}\)',
+            'get_mq_manager_status': 'dspmq -m {0} -o all',
+            'get_mq_managers': 'dspmq',
+            'get_queues': 'display queue\(*\) TYPE\(QLOCAL\) CURDEPTH MAXDEPTH',
+            'get_queues_monitor': 'display qstatus\(\*\) MONITOR'
+        }
+    else:
+        command_mapping = {
+            'get_channels': 'display channel (*)',
+            'get_chstatus': 'display chstatus({0}) BATCHES BUFSRCVD BUFSSENT BYTSRCVD BYTSSENT CHSTADA CHSTATI JOBNAME LSTMSGDA LSTMSGTI MSGS',
+            'get_channel': 'display channel({0})',
+            'get_listeners': 'display listener(*)',
+            'get_listener': 'display listener({0})',
+            'get_lsstatus': 'display lsstatus({0})',
+            'get_mq_manager_status': 'dspmq -m {0} -o all',
+            'get_mq_managers': 'dspmq',
+            'get_queues': 'display queue(*) TYPE(QLOCAL) CURDEPTH MAXDEPTH',
+            'get_queues_monitor': 'display qstatus(*) MONITOR'
+        }
     task_is_mq_manager_status = False
     mq_object = str()
     mq_manager = str()
@@ -27,16 +43,27 @@ def run_mq_command(**kwargs):
             mq_command = command_mapping[arg_value]
         elif arg_name == 'mqm':
             mq_manager = arg_value
-        else:
+        elif arg_name != 'ssh_connect_string':
+            # channel or listener
             mq_object = arg_value
     if mq_object and mq_manager:
-        command = 'echo "{0}"| runmqsc {1}'.format(mq_command.format(mq_object), mq_manager)
+        if ssh_connect_string:
+            command = "echo \"echo {0}\" \| runmqsc {1} > cmd && ssh -q '{2}' 'bash -s' < cmd".format(mq_command.format(mq_object), mq_manager, ssh_connect_string)
+        else:
+            command = 'echo "{0}"| runmqsc {1}'.format(mq_command.format(mq_object), mq_manager)
     elif not mq_object and (mq_manager):
-        command = 'echo "{0}"| runmqsc {1}'.format(mq_command, mq_manager)
+        if ssh_connect_string:
+            command = "echo \"echo {0}\" \| runmqsc {1} > cmd && ssh -q '{2}' 'bash -s' < cmd".format(mq_command, mq_manager, ssh_connect_string)
+        else:
+            command = 'echo "{0}"| runmqsc {1}'.format(mq_command, mq_manager)
     elif not mq_manager:
         command = mq_command
+        if ssh_connect_string:
+            command = "echo {0} > cmd && ssh -q '{1}' 'bash -s' < cmd".format(command, ssh_connect_string)
     if task_is_mq_manager_status:
         command = mq_command.format(mq_manager)
+        if ssh_connect_string:
+            command = "echo {0} > cmd && ssh -q '{1}' 'bash -s' < cmd".format(command, ssh_connect_string)
     output = execute_command(command=command)
     return output
 

--- a/modules/mq_channels.py
+++ b/modules/mq_channels.py
@@ -35,9 +35,9 @@ def get_metric_annotation():
     return annotations
 
 
-def channels_status(mqm):
+def channels_status(mqm, ssh_connect_string=None):
     """Returns dictionary with channels data."""
-    channels = run_mq_command(task='get_channels', mqm=mqm)
+    channels = run_mq_command(task='get_channels', mqm=mqm, ssh_connect_string=ssh_connect_string)
     channels_list = get_channels(channels_data=channels)
     mq_channels_status = {}
     for channel in channels_list:
@@ -46,14 +46,16 @@ def channels_status(mqm):
             channel_data = run_mq_command(
                 task='get_chstatus',
                 mqm=mqm,
-                channel=channel_name)
+                channel=channel_name,
+                ssh_connect_string=ssh_connect_string)
             labels_data = []
             stop_flag = "not found"
             if stop_flag in channel_data:
                 channel_labels = run_mq_command(
                     task='get_channel',
                     mqm=mqm,
-                    channel=channel_name)
+                    channel=channel_name,
+                    ssh_connect_string=ssh_connect_string)
                 labels_data = format_channel_output(data_to_format=channel_labels)
             else:
                 labels_data = format_channel_output(data_to_format=channel_data)

--- a/modules/mq_listener.py
+++ b/modules/mq_listener.py
@@ -23,7 +23,7 @@ def get_metric_annotation():
     return annotations
 
 
-def get_mq_listeners_metrics(listeners, mq_manager):
+def get_mq_listeners_metrics(listeners, mq_manager, ssh_connect_string=None):
     """Returns string with status listeners metrics which ready to push to pushgateway."""
     metrics_annotation = get_metric_annotation()
     prometheus_data_list = list()
@@ -31,11 +31,13 @@ def get_mq_listeners_metrics(listeners, mq_manager):
         listener_data = run_mq_command(
             task='get_lsstatus',
             mqm=mq_manager,
-            listener=listener)
+            listener=listener,
+            ssh_connect_string=ssh_connect_string)
         listener_labels = run_mq_command(
             task='get_listener',
             mqm=mq_manager,
-            listener=listener)
+            listener=listener,
+            ssh_connect_string=ssh_connect_string)
         listener_status = get_listener_status(
             listener_data=listener_data,
             listener_labels=listener_labels)

--- a/modules/mq_queues.py
+++ b/modules/mq_queues.py
@@ -41,17 +41,17 @@ def get_metric_annotation_monitor():
     return annotations
 
 
-def get_queues_metrics(mq_manager):
+def get_queues_metrics(mq_manager, ssh_connect_string=None):
     """Returns string with all main queues metrics which ready to push to pushgateway."""
-    queue_labels_data = run_mq_command(task='get_queues', mqm=mq_manager)
+    queue_labels_data = run_mq_command(task='get_queues', mqm=mq_manager, ssh_connect_string=ssh_connect_string)
     queues_labels = get_queues_labels(queue_labels_data=queue_labels_data)
     queues_metrics = make_metrics_data_for_queues(queues_labels=queues_labels, mq_manager=mq_manager)
     return queues_metrics
 
 
-def get_queues_metrics_monitor(mq_manager):
+def get_queues_metrics_monitor(mq_manager, ssh_connect_string=None):
     """Returns string with all real-time monitoring metrics which ready to push to pushgateway."""
-    queue_labels_data_monitor = run_mq_command(task='get_queues_monitor', mqm=mq_manager)
+    queue_labels_data_monitor = run_mq_command(task='get_queues_monitor', mqm=mq_manager, ssh_connect_string=ssh_connect_string)
     queues_labels_monitor = get_queues_labels_monitor(queue_labels_data=queue_labels_data_monitor)
     queues_metrics_monitor = make_metrics_data_for_queues_monitor(queues_labels=queues_labels_monitor, mq_manager=mq_manager)
     return queues_metrics_monitor


### PR DESCRIPTION
- add a specific logger to enable multi-instances on the same server
- add compatibility flag for MQV7.0 (fix qmanager status)

I find it easier to run the tool remotely due to the python 3 requirement (even with pyenv, pyenv requires some dependencies that we may not want to install to each server running mq). This PR makes it possible to run the exporter remotely through an ssh connection (ssh keys needs to be exchanged beforehand with `ssh-copy-id user@host`). 

It's not the most elegant code ever but it works for our use case :)

Don't know if you'll be interested in merging this, if yes I can add a bit of documentation. 

Run with: 
```
METRICS_LOGS_INSTANCE=host_alias nohup python3 mq_metrics_client.py --pghost <pghost> --pgport <pgport> --ssh_connect_string '<user>@<host>' --compatible v7.0 &
```

- `METRICS_LOGS_INSTANCE` : makes it possible to run multiple instances without risk of concurrent writes on the log file
- `--compatible` : i've found that the dspmq command on mqv7.0 isn't behaving as expected in the code (missing fields). the flag fixes this issue

```
dspmq -m myqmanager -o all
QMNAME(myqmanager )                                           STATUS(Running) DEFAULT(no) STANDBY(Not permitted)
```
I know v7.0 was not officially supported, but with this it seems to work fine. 
